### PR TITLE
simplify code

### DIFF
--- a/Convert Excel to JSON/CSV to JSON/NET Standard/CSV To JSON/CSV To JSON/Program.cs
+++ b/Convert Excel to JSON/CSV to JSON/NET Standard/CSV To JSON/CSV To JSON/Program.cs
@@ -27,9 +27,6 @@ namespace CSV_To_JSON
                 //Active worksheet
                 IWorksheet worksheet = workbook.Worksheets[0];
 
-                //Custom range
-                IRange range = worksheet.Range["A2:A5"];
-
                 //Save the workbook to a JSON file
                 workbook.SaveAsJson("WorkbookToJSON.json");
             }


### PR DESCRIPTION
remove unnecessary assignment to a range, as it is not used in the SaveAsJson method call. Also makes clearer the difference between just a small subset or the whole worksheet.